### PR TITLE
Port nuget 4698 workaround v1.0.2

### DIFF
--- a/src/build/netstandard1.0/MSBuild.Sdk.Extras.targets
+++ b/src/build/netstandard1.0/MSBuild.Sdk.Extras.targets
@@ -4,12 +4,13 @@
   <!-- https://raw.githubusercontent.com/AArnott/NuGet4698Workaround/master/build/NuGet4698Workaround.targets -->
   <Target Name="PackSatelliteAssemblies"
           BeforeTargets="_WalkEachTargetPerFramework"
-          DependsOnTargets="SatelliteDllsProjectOutputGroupWithTargetFramework">
+          DependsOnTargets="SatelliteDllsProjectOutputGroupWithTargetFramework"
+          Condition=" '$(IncludeBuildOutput)' != 'false' ">
     <ItemGroup>
       <Content Include="@(_SatelliteDllsProjectOutputGroupOutputWithTargetFramework)"
                Condition=" '%(_SatelliteDllsProjectOutputGroupOutputWithTargetFramework.Culture)' != '' ">
         <Pack>true</Pack>
-        <PackagePath>lib\%(TargetFramework)\%(TargetPath)</PackagePath>
+        <PackagePath>lib\%(_SatelliteDllsProjectOutputGroupOutputWithTargetFramework.TargetFramework)\%(_SatelliteDllsProjectOutputGroupOutputWithTargetFramework.TargetPath)</PackagePath>
       </Content>
     </ItemGroup>
   </Target>


### PR DESCRIPTION
This fixes a couple issues in the v1.0.1 version that was ported to this project.

See https://github.com/AArnott/NuGet4698Workaround/commit/ca908702ad36349b5e8864c6535a458fcf6e5249 and https://github.com/AArnott/NuGet4698Workaround/commit/0eb704fc43c01f8ef9d729faa94567d5acb704b5