### PR TITLE
use Windows 8.1 Api for win81 builds (...\Windows Kits\8.1\References\CommonConfiguration\Neutral\Windows.winmd)

### DIFF
--- a/MSBuild.Sdk.Extras/build/platforms/Windows.targets
+++ b/MSBuild.Sdk.Extras/build/platforms/Windows.targets
@@ -4,6 +4,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'win' or '$(TargetFramework)' == 'win8' or '$(TargetFramework)' == 'win80'">
+		<TargetPlatformVersion>8.0</TargetPlatformVersion>
 		<TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
 		<NugetTargetMoniker>Windows,Version=v8.0</NugetTargetMoniker>
 		<DefineConstants Condition="'$(DisableImplicitFrameworkDefines)' != 'true'">$(DefineConstants);NETFX_CORE;WINDOWS_APP</DefineConstants>
@@ -14,6 +15,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(TargetFramework)' == 'win81'">
+		<TargetPlatformVersion>8.1</TargetPlatformVersion>
 		<TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
 		<NugetTargetMoniker>Windows,Version=v8.1</NugetTargetMoniker>
 		<DefineConstants Condition="'$(DisableImplicitFrameworkDefines)' != 'true'">$(DefineConstants);NETFX_CORE;WINDOWS_APP</DefineConstants>


### PR DESCRIPTION
By setting TargetPlatformVersion msbuild selects the right Windows.winmd File for the win81 Target. Without it selectes the Windows.winmd
(...\Windows Kits\8.0\References\CommonConfiguration\Neutral\Windows.winmd)
 file for Windows 8.0 which leads to compilation errors because of missing APIs.