### PR TITLE
Don't include WPF on non-Windows. Fixes #33

### DIFF
--- a/MSBuild.Sdk.Extras/build/platforms/NETFramework.targets
+++ b/MSBuild.Sdk.Extras/build/platforms/NETFramework.targets
@@ -3,7 +3,7 @@
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
 
-  <Import Project="$(MSBuildThisFileDirectory)languageTargets\Wpf.targets" />
+  <Import Project="$(MSBuildThisFileDirectory)languageTargets\Wpf.targets" Condition=" '$(OS)' == 'Windows_NT' " />
 
   <!-- Settings only apply to .NET Framework -->
   <ItemGroup Condition="'$(EnableDefaultItems)' == 'True' and '$(EnableDefaultSettingsItems)' == 'true' ">


### PR DESCRIPTION
WPF is only ever supported on Windows, so don't include the Wpf.targets file.