### PR TITLE
Add SDK artifacts

### DIFF
--- a/MSBuild.Sdk.Extras/Sdk/Sdk.props
+++ b/MSBuild.Sdk.Extras/Sdk/Sdk.props
@@ -1,0 +1,9 @@
+<Project>
+
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+  </PropertyGroup>
+
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk"/>
+  <Import Project="$(MSBuildThisFileDirectory)..\build\MSBuild.Sdk.Extras.props"  />
+</Project>

--- a/MSBuild.Sdk.Extras/Sdk/Sdk.targets
+++ b/MSBuild.Sdk.Extras/Sdk/Sdk.targets
@@ -1,0 +1,9 @@
+<Project>
+
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+  </PropertyGroup>
+
+  <Import Project="$(MSBuildSDKExtrasTargets)" />
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk"/>
+</Project>

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.2.1",
+  "version": "1.2.2",
   "publicReleaseRefSpec": [
     "^refs/heads/master$", // we release out of master
     "^refs/heads/dev$", // we release out of develop


### PR DESCRIPTION
This allows referencing the extras with the simplified syntax:

```
<Project Sdk="MSBuild.Sdk.Extras/1.2.2">
...
</Project>
```

The Microsoft.NET.Sdk is automatically imported at the right
time, so the workaround for Microsoft/msbuild#1045 is no longer
needed.