### PR TITLE
Support building Xamarin binding projects

### DIFF
--- a/MSBuild.Sdk.Extras/build/platforms/MonoAndroid.targets
+++ b/MSBuild.Sdk.Extras/build/platforms/MonoAndroid.targets
@@ -11,6 +11,7 @@
 		<AndroidResgenFile Condition="'$(AndroidResgenFile)' == ''">$(IntermediateOutputPath)$(TargetFramework)\Resource.Designer$(_SdkLanguageExtension)</AndroidResgenFile>
 		<!-- This is here to prevent a warning in the Xamarin.Android.Common.Debugging.targets when a blank is passed into _GetPrimaryCpuAbi -->
 		<AdbTarget Condition="'$(AdbTarget)' == ''">none</AdbTarget>
+		<AndroidClassParser Condition="'$(AndroidClassParser)' == ''">class-parse</AndroidClassParser>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(DisableImplicitFrameworkReferences)' != 'true'">

--- a/MSBuild.Sdk.Extras/build/platforms/languageTargets/MonoAndroid.targets
+++ b/MSBuild.Sdk.Extras/build/platforms/languageTargets/MonoAndroid.targets
@@ -3,9 +3,16 @@
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
 
+	<PropertyGroup>
+		<!-- check if this is a binding project -->
+		<_SdkAndroidImportType>$(_SdkLanguageName)</_SdkAndroidImportType>
+		<!-- TODO: throw an error if the _SdkLanguageName != CSharp as that is the only language supported -->
+		<_SdkAndroidImportType Condition="'$(IsJavaBindingProject)' == 'true'">Bindings</_SdkAndroidImportType>
+	</PropertyGroup>
+
   <ImportGroup>
-		<Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.$(_SdkLanguageName).targets"
-				Condition="Exists('$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.$(_SdkLanguageName).targets')" />
+		<Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.$(_SdkAndroidImportType).targets"
+				Condition="Exists('$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.$(_SdkAndroidImportType).targets')" />
 
 		<Import Project="$(MSBuildThisFileDirectory)CommonAfter.targets" />
 	</ImportGroup>

--- a/MSBuild.Sdk.Extras/build/platforms/languageTargets/MonoAndroid.targets
+++ b/MSBuild.Sdk.Extras/build/platforms/languageTargets/MonoAndroid.targets
@@ -7,7 +7,7 @@
 		<!-- check if this is a binding project -->
 		<_SdkAndroidImportType>$(_SdkLanguageName)</_SdkAndroidImportType>
 		<!-- TODO: throw an error if the _SdkLanguageName != CSharp as that is the only language supported -->
-		<_SdkAndroidImportType Condition="'$(IsJavaBindingProject)' == 'true'">Bindings</_SdkAndroidImportType>
+		<_SdkAndroidImportType Condition="'$(IsBindingProject)' == 'true'">Bindings</_SdkAndroidImportType>
 	</PropertyGroup>
 
   <ImportGroup>

--- a/MSBuild.Sdk.Extras/build/platforms/languageTargets/Xamarin.Mac.targets
+++ b/MSBuild.Sdk.Extras/build/platforms/languageTargets/Xamarin.Mac.targets
@@ -3,9 +3,15 @@
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
 
+	<PropertyGroup>
+		<!-- check if this is a binding project -->
+		<!-- TODO: throw an error if the _SdkLanguageName != CSharp as that is the only language supported -->
+		<_SdkObjCBinding Condition="'$(IsObjCBindingProject)' == 'true'">.ObjCBinding</_SdkObjCBinding>
+	</PropertyGroup>
+
   <ImportGroup>
-		<Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.$(_SdkLanguageName).targets"
-				Condition="Exists('$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.$(_SdkLanguageName).targets')" />
+		<Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac$(_SdkObjCBinding).$(_SdkLanguageName).targets"
+				Condition="Exists('$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac$(_SdkObjCBinding).$(_SdkLanguageName).targets')" />
 	
 		<Import Project="$(MSBuildThisFileDirectory)CommonAfter.targets" />
 	</ImportGroup>

--- a/MSBuild.Sdk.Extras/build/platforms/languageTargets/Xamarin.Mac.targets
+++ b/MSBuild.Sdk.Extras/build/platforms/languageTargets/Xamarin.Mac.targets
@@ -6,7 +6,7 @@
 	<PropertyGroup>
 		<!-- check if this is a binding project -->
 		<!-- TODO: throw an error if the _SdkLanguageName != CSharp as that is the only language supported -->
-		<_SdkObjCBinding Condition="'$(IsObjCBindingProject)' == 'true'">.ObjCBinding</_SdkObjCBinding>
+		<_SdkObjCBinding Condition="'$(IsBindingProject)' == 'true'">.ObjCBinding</_SdkObjCBinding>
 	</PropertyGroup>
 
   <ImportGroup>

--- a/MSBuild.Sdk.Extras/build/platforms/languageTargets/Xamarin.TVOS.targets
+++ b/MSBuild.Sdk.Extras/build/platforms/languageTargets/Xamarin.TVOS.targets
@@ -6,7 +6,7 @@
 	<PropertyGroup>
 		<!-- check if this is a binding project -->
 		<!-- TODO: throw an error if the _SdkLanguageName != CSharp as that is the only language supported -->
-		<_SdkObjCBinding Condition="'$(IsObjCBindingProject)' == 'true'">.ObjCBinding</_SdkObjCBinding>
+		<_SdkObjCBinding Condition="'$(IsBindingProject)' == 'true'">.ObjCBinding</_SdkObjCBinding>
 	</PropertyGroup>
 
   <ImportGroup>

--- a/MSBuild.Sdk.Extras/build/platforms/languageTargets/Xamarin.TVOS.targets
+++ b/MSBuild.Sdk.Extras/build/platforms/languageTargets/Xamarin.TVOS.targets
@@ -3,9 +3,15 @@
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
 
+	<PropertyGroup>
+		<!-- check if this is a binding project -->
+		<!-- TODO: throw an error if the _SdkLanguageName != CSharp as that is the only language supported -->
+		<_SdkObjCBinding Condition="'$(IsObjCBindingProject)' == 'true'">.ObjCBinding</_SdkObjCBinding>
+	</PropertyGroup>
+
   <ImportGroup>
-		<Import Project="$(MSBuildExtensionsPath)\Xamarin\TVOS\Xamarin.TVOS.$(_SdkLanguageName).targets"
-				Condition="Exists('$(MSBuildExtensionsPath)\Xamarin\TVOS\Xamarin.TVOS.$(_SdkLanguageName).targets')" />
+		<Import Project="$(MSBuildExtensionsPath)\Xamarin\TVOS\Xamarin.TVOS$(_SdkObjCBinding).$(_SdkLanguageName).targets"
+				Condition="Exists('$(MSBuildExtensionsPath)\Xamarin\TVOS\Xamarin.TVOS$(_SdkObjCBinding).$(_SdkLanguageName).targets')" />
 	
 		<Import Project="$(MSBuildThisFileDirectory)CommonAfter.targets" />
 	</ImportGroup>

--- a/MSBuild.Sdk.Extras/build/platforms/languageTargets/Xamarin.WatchOS.targets
+++ b/MSBuild.Sdk.Extras/build/platforms/languageTargets/Xamarin.WatchOS.targets
@@ -6,7 +6,7 @@
 	<PropertyGroup>
 		<!-- check if this is a binding project -->
 		<!-- TODO: throw an error if the _SdkLanguageName != CSharp as that is the only language supported -->
-		<_SdkObjCBinding Condition="'$(IsObjCBindingProject)' == 'true'">.ObjCBinding</_SdkObjCBinding>
+		<_SdkObjCBinding Condition="'$(IsBindingProject)' == 'true'">.ObjCBinding</_SdkObjCBinding>
 	</PropertyGroup>
 
   <ImportGroup>

--- a/MSBuild.Sdk.Extras/build/platforms/languageTargets/Xamarin.WatchOS.targets
+++ b/MSBuild.Sdk.Extras/build/platforms/languageTargets/Xamarin.WatchOS.targets
@@ -3,9 +3,15 @@
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
 
+	<PropertyGroup>
+		<!-- check if this is a binding project -->
+		<!-- TODO: throw an error if the _SdkLanguageName != CSharp as that is the only language supported -->
+		<_SdkObjCBinding Condition="'$(IsObjCBindingProject)' == 'true'">.ObjCBinding</_SdkObjCBinding>
+	</PropertyGroup>
+
   <ImportGroup>
-		<Import Project="$(MSBuildExtensionsPath)\Xamarin\WatchOS\Xamarin.WatchOS.$(_SdkLanguageName).targets"
-				Condition="Exists('$(MSBuildExtensionsPath)\Xamarin\WatchOS\Xamarin.WatchOS.$(_SdkLanguageName).targets')" />
+		<Import Project="$(MSBuildExtensionsPath)\Xamarin\WatchOS\Xamarin.WatchOS$(_SdkObjCBinding).$(_SdkLanguageName).targets"
+				Condition="Exists('$(MSBuildExtensionsPath)\Xamarin\WatchOS\Xamarin.WatchOS$(_SdkObjCBinding).$(_SdkLanguageName).targets')" />
 	
 		<Import Project="$(MSBuildThisFileDirectory)CommonAfter.targets" />
 	</ImportGroup>

--- a/MSBuild.Sdk.Extras/build/platforms/languageTargets/Xamarin.iOS.targets
+++ b/MSBuild.Sdk.Extras/build/platforms/languageTargets/Xamarin.iOS.targets
@@ -3,9 +3,15 @@
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
 
+	<PropertyGroup>
+		<!-- check if this is a binding project -->
+		<!-- TODO: throw an error if the _SdkLanguageName != CSharp as that is the only language supported -->
+		<_SdkObjCBinding Condition="'$(IsObjCBindingProject)' == 'true'">.ObjCBinding</_SdkObjCBinding>
+	</PropertyGroup>
+
   <ImportGroup>
-		<Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.$(_SdkLanguageName).targets"
-				Condition="Exists('$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.$(_SdkLanguageName).targets')" />
+		<Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS$(_SdkObjCBinding).$(_SdkLanguageName).targets"
+				Condition="Exists('$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS$(_SdkObjCBinding).$(_SdkLanguageName).targets')" />
 
 		<Import Project="$(MSBuildThisFileDirectory)CommonAfter.targets" />
 	</ImportGroup>

--- a/MSBuild.Sdk.Extras/build/platforms/languageTargets/Xamarin.iOS.targets
+++ b/MSBuild.Sdk.Extras/build/platforms/languageTargets/Xamarin.iOS.targets
@@ -6,7 +6,7 @@
 	<PropertyGroup>
 		<!-- check if this is a binding project -->
 		<!-- TODO: throw an error if the _SdkLanguageName != CSharp as that is the only language supported -->
-		<_SdkObjCBinding Condition="'$(IsObjCBindingProject)' == 'true'">.ObjCBinding</_SdkObjCBinding>
+		<_SdkObjCBinding Condition="'$(IsBindingProject)' == 'true'">.ObjCBinding</_SdkObjCBinding>
 	</PropertyGroup>
 
   <ImportGroup>


### PR DESCRIPTION
The ability to build a binding library (as opposed to a normal class library) is beneficial if you are adding native resources that must be embedded into the final assembly.

Examples would be
 - a native iOS .framework
 - a native Android .so
 - a native macOS .dylib

These _can_ be added to the package as part of a build/.targets combination, but this does not cater for other tooling that may be used, such as designers or Xamarin.Workbooks which look inside the assembly.

Current support:
 - Xamarin.Mac
 - Xamarin.WatchOS
 - Xamarin.TVOS
 - Xamarin.iOS
 - Xamarin.Android

The project format is the same as usual, except for a property that indicates that this is a binding project:

```xml
<IsBindingProject>true</IsBindingProject>
```

An example file:

```xml
<Project Sdk="Microsoft.NET.Sdk">
    <PropertyGroup>
        <TargetFrameworks>Xamarin.iOS10;MonoAndroid2.3;netstandard2.0</TargetFrameworks>
        <EnableDefaultItems>false</EnableDefaultItems>
    </PropertyGroup>
    <ItemGroup>
        <PackageReference Include="MSBuild.Sdk.Extras" Version="1.2.2" PrivateAssets="All" />
    </ItemGroup>

    <ItemGroup>
        <!-- any regular C# files -->
        <Compile Include="Shared\**\*.cs" />
    </ItemGroup>

    <PropertyGroup Condition=" $(TargetFramework.StartsWith('MonoAndroid')) ">
        <IsBindingProject>true</IsBindingProject>
    </PropertyGroup>
    <ItemGroup Condition=" $(TargetFramework.StartsWith('MonoAndroid')) ">
        <!-- this would be for any Java bindings -->
        <LibraryProjectZip Include="android\SkiaSharp.aar" />
        <TransformFile Include="Transforms\EnumFields.xml" />
        <TransformFile Include="Transforms\EnumMethods.xml" />
        <TransformFile Include="Transforms\Metadata.xml" />
        <!-- this would be for any native libraries -->
        <EmbeddedNativeLibrary Include="android\arm64-v8a\libSkiaSharp.so" Link="libs\arm64-v8a\libSkiaSharp.so" />
        <EmbeddedNativeLibrary Include="android\armeabi-v7a\libSkiaSharp.so" Link="libs\armeabi-v7a\libSkiaSharp.so" />
        <EmbeddedNativeLibrary Include="android\x86\libSkiaSharp.so" Link="libs\x86\libSkiaSharp.so" />
        <EmbeddedNativeLibrary Include="android\x86_64\libSkiaSharp.so" Link="libs\x86_64\libSkiaSharp.so" />
    </ItemGroup>

    <PropertyGroup Condition=" $(TargetFramework.StartsWith('Xamarin.iOS')) ">
        <IsBindingProject>true</IsBindingProject>
    </PropertyGroup>
    <ItemGroup Condition=" $(TargetFramework.StartsWith('Xamarin.iOS')) ">
        <!-- the native framework -->
        <NativeReference Include="libSkiaSharp.framework" Kind="Framework" />
        <!-- the binding-specific files -->
        <ObjcBindingApiDefinition Include="iOSBinding\ApiDefinition.cs" />
        <ObjcBindingCoreSource Include="iOSBinding\Structs.cs" />
    </ItemGroup>

    <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
</Project>
```