### PR TITLE
Publish locally produced nuget package for easy consumption

### DIFF
--- a/MSBuild.Sdk.Extras/MSBuild.Sdk.Extras.csproj
+++ b/MSBuild.Sdk.Extras/MSBuild.Sdk.Extras.csproj
@@ -26,4 +26,7 @@
 
     <None Update="**\*.props;**\*.targets;**\*.xml;**\*.xaml" Pack="true" PackagePath="." />
   </ItemGroup>
+
+  <Import Project="MSBuild.Sdk.Extras.targets" />
+
 </Project>

--- a/MSBuild.Sdk.Extras/MSBuild.Sdk.Extras.targets
+++ b/MSBuild.Sdk.Extras/MSBuild.Sdk.Extras.targets
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(CI)' == ''">
+    <CI Condition="'$(TEAMCITY_VERSION)' != '' or 
+                   '$(APPVEYOR)' != '' or 
+                   '$(BuildRunner)' == 'MyGet' or 
+                   '$(JENKINS_HOME)' != '' or 
+                   '$(TF_BUILD)' == 'true' or
+                   '$(IsVSTSBuild)' == 'true' or
+                   '$(TRAVIS)' == 'true'">true</CI>
+    <CI Condition="'$(CI)' == ''">false</CI>
+  </PropertyGroup>
+
+  <Target Name="_LocalPublish" Condition="'$(CI)' != 'true'" AfterTargets="Pack">
+    <Exec Command='rd "$(NuGetPackageRoot)$(PackageId.ToLowerInvariant())" /q /s' Condition="Exists('$(NuGetPackageRoot)$(PackageId.ToLowerInvariant())')" />
+
+    <ItemGroup>
+      <ToDelete Include="$(TEMP)\packages\$(PackageId)*.nupkg" />
+    </ItemGroup>
+    <Delete Files="@(ToDelete)" />
+
+    <MakeDir Directories="$(TEMP)\packages" Condition="!Exists('$(TEMP)\packages')" />
+    <Copy SourceFiles="$(PackageOutputPath)\$(PackageId).$(PackageVersion).nupkg" DestinationFolder="$(TEMP)\packages" />
+  </Target>
+
+</Project>


### PR DESCRIPTION
Locally testing nuget-producing projects is always a bit tricky.
You have to basically:

1 - Clean the output folder from previously produced packages
2 - Add the output folder as a nuget source on the consuming project
3 - Clean the nuget restore cache so that the newly produced .nupkg
    from the new source will always be unpacked, rather than picked
    up from a previous build already cached
4 - Repeat for every project that produces packages ;-)

We can do better!

This change adds a target `_LocalPublish` that will only run on local
builds, which does all of the above, but copying the output to
`%TEMP%\packages`, so that to test packages, you only need to add a single
source in a `NuGet.Config` (could even be a machine-wide one ;)):

```xml
<configuration>
	<packageSources>
		<add key="local" value="%temp%\packages" />
	</packageSources>
</configuration>
```

Re-packing the project would automatically clear the nuget cache (just
for the package machine the current `$(PackageId)` of course), delete
previously built versions, and copy the output to the temp path.

This way, rapidly iterating on the packaging output becomes even
enjoyable!