### PR TITLE
Fix $(CI) property to only check for AppVeyor

### DIFF
--- a/MSBuild.Sdk.Extras/MSBuild.Sdk.Extras.targets
+++ b/MSBuild.Sdk.Extras/MSBuild.Sdk.Extras.targets
@@ -6,14 +6,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(CI)' == ''">
-    <CI Condition="'$(TEAMCITY_VERSION)' != '' or 
-                   '$(ContinuaCI.Version)' != '' or
-                   '$(APPVEYOR)' != '' or 
-                   '$(BuildRunner)' == 'MyGet' or 
-                   '$(JENKINS_HOME)' != '' or 
-                   '$(TF_BUILD)' == 'true' or
-                   '$(IsVSTSBuild)' == 'true' or
-                   '$(TRAVIS)' == 'true'">true</CI>
+    <CI Condition="'$(APPVEYOR)' != '' or '$(TF_BUILD)' == 'true'">true</CI>
     <CI Condition="'$(CI)' == ''">false</CI>
   </PropertyGroup>
 


### PR DESCRIPTION
Since this project itself is only ever built on AppVeyor, the extra
checks I brought from a general-purpose .props file don't make sense
and can actually confuse contributors, such as in #40 where support
for an extra CI system the project doesn't use in any way, broke the
IDE project loading.