### PR TITLE
Delete local nuget cache at the end

### DIFF
--- a/MSBuild.Sdk.Extras/MSBuild.Sdk.Extras.targets
+++ b/MSBuild.Sdk.Extras/MSBuild.Sdk.Extras.targets
@@ -20,8 +20,6 @@
   </Target>
 
   <Target Name="_LocalPublish" Condition="'$(CI)' != 'true'" AfterTargets="Pack">
-    <Exec Command='rd "$(NuGetPackageRoot)$(PackageId.ToLowerInvariant())" /q /s' Condition="Exists('$(NuGetPackageRoot)$(PackageId.ToLowerInvariant())')" />
-
     <ItemGroup>
       <ToDelete Include="$(TEMP)\packages\$(PackageId)*.nupkg" />
     </ItemGroup>
@@ -29,6 +27,8 @@
 
     <MakeDir Directories="$(TEMP)\packages" Condition="!Exists('$(TEMP)\packages')" />
     <Copy SourceFiles="$(PackageOutputPath)\$(PackageId).$(PackageVersion).nupkg" DestinationFolder="$(TEMP)\packages" />
+
+    <Exec Command='rd "$(NuGetPackageRoot)$(PackageId.ToLowerInvariant())" /q /s' Condition="Exists('$(NuGetPackageRoot)$(PackageId.ToLowerInvariant())')" />
   </Target>
 
 </Project>


### PR DESCRIPTION
Ensure the copying of the new version is performed before attempting
to delete the user cache, since VS might be holding some files or
folders and delete sometimes fails, but the new package can still
work fine. Since this is sort of random, I'd rather have the build
fail *after* the local package was copied to $temp$\packages, at
which point I can try out myself to see if the deletion of the
cache is actually required or not for local testing.