### PR TITLE
Rids

### DIFF
--- a/Source/MSBuild.Sdk.Extras/Build/Core.targets
+++ b/Source/MSBuild.Sdk.Extras/Build/Core.targets
@@ -19,6 +19,8 @@
             Condition="'$(TargetFrameworkIdentifier)' != ''"/>
   </ImportGroup>
 
+
+  <Import Project="$(MSBuildThisFileDirectory)RIDs.targets"/>
   <Import Project="$(MSBuildThisFileDirectory)..\DefaultItems\DefaultItems.targets"/>
   <Import Project="$(MSBuildThisFileDirectory)..\ProjectSystem\ProjectSystem.targets"/>
 

--- a/Source/MSBuild.Sdk.Extras/Build/Inference.targets
+++ b/Source/MSBuild.Sdk.Extras/Build/Inference.targets
@@ -26,7 +26,8 @@
       portable45-net45+win8+wp8+wpa81 into 'portable', '45', '+net45+win8+wp8+wpa81+'
   -->
   <Choose>
-    <When Condition="$(TargetFramework.Contains('-'))">
+    <!-- If the - has portable, client, or cf in it, treat as profile -->
+    <When Condition="$(TargetFramework.Contains('-')) and ($(TargetFramework.Contains('portable')) or $(TargetFramework.Contains('-client')) or $(TargetFramework.Contains('-cf')) ) ">
       <!-- Handle short framework ids with profiles -->
       <PropertyGroup>
         <_SdkShortFrameworkIdentifierWithVersion>$(TargetFramework.Split('-')[0])</_SdkShortFrameworkIdentifierWithVersion>
@@ -39,6 +40,16 @@
       </PropertyGroup>
     </When>
 
+    <!-- If the TFM has a +, the part afterwards will be the RID -->
+    <When Condition="$(TargetFramework.Contains('+'))">
+      <PropertyGroup>
+        <_SdkShortFrameworkIdentifierWithVersion>$(TargetFramework.Split('+')[0])</_SdkShortFrameworkIdentifierWithVersion>
+        <_SdkShortFrameworkIdentifier>$(_SdkShortFrameworkIdentifierWithVersion.TrimEnd('.0123456789'))</_SdkShortFrameworkIdentifier>
+        <_SdkShortFrameworkVersion>$(_SdkShortFrameworkIdentifierWithVersion.Substring($(_SdkShortFrameworkIdentifier.Length)))</_SdkShortFrameworkVersion>
+        <_SdkRuntimeId>$(TargetFramework.Split('+')[1])</_SdkRuntimeId>
+        <RuntimeIdentifier>$(_SdkRuntimeId)</RuntimeIdentifier>
+      </PropertyGroup>
+    </When>
     <Otherwise>
       <!-- Handle simple short framework ids -->
       <PropertyGroup>

--- a/Source/MSBuild.Sdk.Extras/Build/Platforms.targets
+++ b/Source/MSBuild.Sdk.Extras/Build/Platforms.targets
@@ -20,7 +20,8 @@
   <!-- Add conditional compilation symbols for the target framework and one with version -->
   <PropertyGroup Condition="'$(DisableImplicitFrameworkDefines)' != 'true'">
     <ImplicitFrameworkIdentifierDefine>$(TargetFrameworkIdentifier.TrimStart('.').Replace('.','_').ToUpperInvariant())</ImplicitFrameworkIdentifierDefine>
-    <ImplicitFrameworkDefine>$(TargetFramework.Replace('.','_').Replace('-','_').ToUpperInvariant())</ImplicitFrameworkDefine>
+    <ImplicitFrameworkDefine>$(TargetFramework.Replace('.','_').Replace('-','_').Replace('+', '_').ToUpperInvariant())</ImplicitFrameworkDefine>
+    <_SdkImplicitFrameworkDefineWithoutRid Condition="'$(_SdkRuntimeId)' != ''">$(_SdkShortFrameworkIdentifierWithVersion.Replace('.','_').Replace('-','_').Replace('+', '_').ToUpperInvariant())</_SdkImplicitFrameworkDefineWithoutRid>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(PlatformTargets)' == ''">
@@ -32,11 +33,13 @@
   <PropertyGroup Condition="'$(DisableImplicitFrameworkDefines)' != 'true' AND '$(_SdkLanguageSourceName)' != 'VisualBasic'">
     <DefineConstants Condition="'$(DefineConstants)' != '' AND !$(DefineConstants.EndsWith(';'))">$(DefineConstants);</DefineConstants>
     <DefineConstants>$(DefineConstants)$(_SdkImplicitFrameworkProfileDefine)</DefineConstants>
+    <DefineConstants Condition="'$(_SdkImplicitFrameworkDefineWithoutRid)' != ''">$(DefineConstants);$(_SdkImplicitFrameworkDefineWithoutRid)</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(DisableImplicitFrameworkDefines)' != 'true' AND '$(_SdkLanguageSourceName)' == 'VisualBasic'">
     <FinalDefineConstants Condition="'$(FinalDefineConstants)' != '' AND !$(DefineConstants.EndsWith(','))">$(FinalDefineConstants),</FinalDefineConstants>
     <FinalDefineConstants Condition="'$(_SdkImplicitFrameworkProfileDefine)' != ''">$(FinalDefineConstants)$(_SdkImplicitFrameworkProfileDefine)=-1</FinalDefineConstants>
+    <FinalDefineConstants Condition="'$(_SdkImplicitFrameworkDefineWithoutRid)' != ''">$(FinalDefineConstants),$(_SdkImplicitFrameworkDefineWithoutRid)=-1</FinalDefineConstants>
   </PropertyGroup>
 
   <!-- The conditional compilation symbols defined in the above import and the property-group flows to the Main SDK -->

--- a/Source/MSBuild.Sdk.Extras/Build/RIDs.targets
+++ b/Source/MSBuild.Sdk.Extras/Build/RIDs.targets
@@ -1,0 +1,48 @@
+﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+  </PropertyGroup>
+
+
+  <Target Name="_ExtrasFilterRidFromRestore" AfterTargets="_GetRestoreTargetFrameworksOutput" BeforeTargets="_GenerateRestoreProjectSpec">
+
+    <ItemGroup>
+      
+      <_SdkUniqueTfms />
+
+      <!-- Get the TFM's that contain an RID -->
+      <_SdkFilteredTfms Include="@(_RestoreTargetFrameworksOutputFiltered)" 
+                        Condition="$([MSBuild]::ValueOrDefault('%(Identity)', '').Contains('+')) and !$([MSBuild]::ValueOrDefault('%(Identity)', '').Contains('portable'))" 
+                        Replacement="$([MSBuild]::ValueOrDefault('%(Identity)', '').Substring(0, $([MSBuild]::ValueOrDefault('%(Identity)', '').IndexOf('+')))  )"
+                        
+                        />
+      
+      <!-- Remove them from the filtered list since NuGet doesn't know about it here -->
+      <_RestoreTargetFrameworksOutputFiltered Remove="@(_SdkFilteredTfms)" />
+    </ItemGroup>
+
+    <RemoveDuplicates
+      Inputs="@(_SdkFilteredTfms->'%(Replacement)')">
+      <Output
+        TaskParameter="Filtered"
+        ItemName="_SdkUniqueTfms" />
+    </RemoveDuplicates>
+
+    <ItemGroup>
+      <_RestoreTargetFrameworksOutputFiltered Include="@(_SdkUniqueTfms)" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_ExtrasFilterRidFromGraphEntry" AfterTargets="_GenerateProjectRestoreGraphCurrentProject;_GenerateProjectRestoreGraphAllFrameworks" BeforeTargets="_GenerateRestoreDependencies">
+
+    <ItemGroup>
+      <_RestoreGraphEntry Update="@(_RestoreGraphEntry)"  
+                          Condition="$([MSBuild]::ValueOrDefault('%(_RestoreGraphEntry.TargetFramework)', '').Contains('+')) and !$([MSBuild]::ValueOrDefault('%(_RestoreGraphEntry.TargetFramework)', '').Contains('portable'))"
+                          TargetFramework="$([MSBuild]::ValueOrDefault('%(_RestoreGraphEntry.TargetFramework)', '').Substring(0, $([MSBuild]::ValueOrDefault('%(_RestoreGraphEntry.TargetFramework)', '').IndexOf('+')))  )"
+                          
+                          />
+      </ItemGroup>
+  </Target>
+
+</Project>

--- a/Source/MSBuild.Sdk.Extras/Build/RIDs.targets
+++ b/Source/MSBuild.Sdk.Extras/Build/RIDs.targets
@@ -39,10 +39,121 @@
     <ItemGroup>
       <_RestoreGraphEntry Update="@(_RestoreGraphEntry)"  
                           Condition="$([MSBuild]::ValueOrDefault('%(_RestoreGraphEntry.TargetFramework)', '').Contains('+')) and !$([MSBuild]::ValueOrDefault('%(_RestoreGraphEntry.TargetFramework)', '').Contains('portable'))"
+                          OriginalTargetFramework="%(_RestoreGraphEntry.TargetFramework)"
                           TargetFramework="$([MSBuild]::ValueOrDefault('%(_RestoreGraphEntry.TargetFramework)', '').Substring(0, $([MSBuild]::ValueOrDefault('%(_RestoreGraphEntry.TargetFramework)', '').IndexOf('+')))  )"
                           
                           />
+      <_RestoreGraphEntry Update="@(_RestoreGraphEntry)"
+                          Condition="$([MSBuild]::ValueOrDefault('%(_RestoreGraphEntry.TargetFrameworks)', '').Contains('+')) and !$([MSBuild]::ValueOrDefault('%(_RestoreGraphEntry.TargetFrameworks)', '').Contains('portable'))"
+                          OriginalTargetFrameworks="%(_RestoreGraphEntry.TargetFrameworks)"
+                          TargetFrameworks="$([MSBuild]::ValueOrDefault('%(_RestoreGraphEntry.TargetFrameworks)', '').Substring(0, $([MSBuild]::ValueOrDefault('%(_RestoreGraphEntry.TargetFrameworks)', '').IndexOf('+')))  )"
+                          
+      />
       </ItemGroup>
+  </Target>
+  
+  
+
+  <PropertyGroup>
+    <_SdkTaskFactoryType Condition="'$(MSBuildRuntimeType)' == 'Full'">CodeTaskFactory</_SdkTaskFactoryType>
+    <_SdkTaskFactoryType Condition="'$(MSBuildRuntimeType)' == 'Core'">RoslynTaskFactory</_SdkTaskFactoryType>
+    <_SdkTaskAssemblyFileName Condition="'$(MSBuildRuntimeType)' == 'Full'">$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll</_SdkTaskAssemblyFileName>
+    <_SdkTaskAssemblyFileName Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildBinPath)\Microsoft.Build.Tasks.Core.dll</_SdkTaskAssemblyFileName>
+  </PropertyGroup>
+  
+
+  <UsingTask TaskName="_ExtrasUpdateTargetsFile"
+             TaskFactory="$(_SdkTaskFactoryType)"
+             AssemblyFile="$(_SdkTaskAssemblyFileName)">
+    <ParameterGroup>
+      <ItemMap ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="true" />
+      <InputFile ParameterType="System.String" Required="true" />
+      <OutputFile ParameterType="System.String" Required="true" />
+    </ParameterGroup>
+    <Task>
+      <Reference Include="System.Xml" />
+      <Reference Include="System.Xml.Linq" />
+      <Using Namespace="System" />
+      <Using Namespace="System.IO" />
+      <Using Namespace="System.Linq" />
+      <Using Namespace="System.Xml.Linq" />
+      <Code Type="Fragment" Language="C#">
+        <![CDATA[
+            var doc = XDocument.Load(File.OpenText(InputFile));
+            var ns = doc.Root.GetDefaultNamespace();
+
+            // Escape this to avoid MSBuild issues
+            var tf = "$" + "(TargetFramework)";
+            
+            // The input has the source in the items
+            var tfms = ItemMap.GroupBy(i => i.GetMetadata("TargetFramework"), i => i.ItemSpec);
+
+            foreach (var tfm in tfms)
+            {
+                var targetString = string.Format("'{0}' == '{1}'", tf, tfm.Key);
+
+                var group = doc.Root.Elements(ns + "ImportGroup")
+                               .FirstOrDefault(ele => ele.Attribute("Condition").Value.Contains(targetString));
+
+                if (group != null)
+                {
+                    var clauses = tfm.Select(t => string.Format("'{0}' == '{1}'",tf, t));
+                    var replacementString = string.Join(" OR ", clauses);
+                    replacementString = string.Format("( {0} )", replacementString);
+
+                    group.Attribute("Condition").Value = group.Attribute("Condition").Value.Replace(targetString, replacementString);
+                }
+
+            }
+
+            doc.Save(OutputFile);
+            ]]>
+      </Code>
+    </Task>
+  </UsingTask>
+
+  
+
+  <Target Name="_ExtrasFixRestoreFiles" 
+          Condition="@(_RestoreGraphEntry->'%(OriginalTargetFrameworks)') != '' or @(_RestoreGraphEntry->'%(OriginalTargetFramework)') != ''"
+          AfterTargets="Restore">
+
+    <ItemGroup>
+      <_SdkTfmToOriginalMapTmp Include="@(_RestoreGraphEntry->'%(OriginalTargetFrameworks)')" TargetFramework="%(_RestoreGraphEntry.TargetFrameworks)" KeepMetadata="TargetFramework" />
+      <_SdkTfmToOriginalMapTmp Include="@(_RestoreGraphEntry->'%(OriginalTargetFramework)')" TargetFramework="%(_RestoreGraphEntry.TargetFramework)" KeepMetadata="TargetFramework" />
+    </ItemGroup>
+    
+    <RemoveDuplicates
+      Inputs="@(_SdkTfmToOriginalMapTmp)">
+      <Output
+        TaskParameter="Filtered"
+        ItemName="_SdkTfmToOriginal" />
+    </RemoveDuplicates>
+
+
+    <PropertyGroup>
+      <_SdkFileLocation>$([MSBuild]::EnsureTrailingSlash($([System.IO.Directory]::GetParent($(ProjectAssetsFile)).FullName)))</_SdkFileLocation>
+      <_SdkPropsFileLocation>$(_SdkFileLocation)$(MSBuildProjectFile).nuget.g.props</_SdkPropsFileLocation>
+      <_SdkTargetsFileLocation>$(_SdkFileLocation)$(MSBuildProjectFile).nuget.g.targets</_SdkTargetsFileLocation>
+      <_SdkTargetsFileLocationOut>$(_SdkFileLocation)$(MSBuildProjectFile).extras.g.targets</_SdkTargetsFileLocationOut>
+      <_SdkPropsFileLocationOut>$(_SdkFileLocation)$(MSBuildProjectFile).extras.g.props</_SdkPropsFileLocationOut>
+    </PropertyGroup>
+    
+    <_ExtrasUpdateTargetsFile 
+      ItemMap="@(_SdkTfmToOriginal)"
+      InputFile="$(_SdkTargetsFileLocation)"
+      OutputFile="$(_SdkTargetsFileLocationOut)"
+      Condition="Exists('$(_SdkTargetsFileLocation)')"
+      />
+    
+    <_ExtrasUpdateTargetsFile 
+      ItemMap="@(_SdkTfmToOriginal)"
+      InputFile="$(_SdkPropsFileLocation)"
+      OutputFile="$(_SdkPropsFileLocationOut)"
+      Condition="Exists('$(_SdkPropsFileLocation)')"
+    />
+    
+
   </Target>
 
 </Project>

--- a/Source/MSBuild.Sdk.Extras/Build/RIDs.targets
+++ b/Source/MSBuild.Sdk.Extras/Build/RIDs.targets
@@ -132,7 +132,7 @@
 
 
     <PropertyGroup>
-      <_SdkFileLocation>$([MSBuild]::EnsureTrailingSlash($([System.IO.Directory]::GetParent($(ProjectAssetsFile)).FullName)))</_SdkFileLocation>
+      <_SdkFileLocation>$(MSBuildProjectExtensionsPath)</_SdkFileLocation>
       <_SdkPropsFileLocation>$(_SdkFileLocation)$(MSBuildProjectFile).nuget.g.props</_SdkPropsFileLocation>
       <_SdkTargetsFileLocation>$(_SdkFileLocation)$(MSBuildProjectFile).nuget.g.targets</_SdkTargetsFileLocation>
       <_SdkTargetsFileLocationOut>$(_SdkFileLocation)$(MSBuildProjectFile).extras.g.targets</_SdkTargetsFileLocationOut>

--- a/Source/MSBuild.Sdk.Extras/Build/RIDs.targets
+++ b/Source/MSBuild.Sdk.Extras/Build/RIDs.targets
@@ -113,10 +113,35 @@
   </UsingTask>
 
   
+  <!--
+    Copy the main targets to make sure we generate the restore file first
+  -->
+  <Target Name="_SdkRestoreOriginal" DependsOnTargets="_GenerateRestoreGraph">
+
+    <!-- Drop any duplicate items -->
+    <RemoveDuplicates
+      Inputs="@(_RestoreGraphEntry)">
+      <Output
+          TaskParameter="Filtered"
+          ItemName="_RestoreGraphEntryFiltered" />
+    </RemoveDuplicates>
+
+    <!-- Call restore -->
+    <RestoreTask
+      RestoreGraphItems="@(_RestoreGraphEntryFiltered)"
+      RestoreDisableParallel="$(RestoreDisableParallel)"
+      RestoreNoCache="$(RestoreNoCache)"
+      RestoreIgnoreFailedSources="$(RestoreIgnoreFailedSources)"
+      RestoreRecursive="$(RestoreRecursive)"
+      RestoreForce="$(RestoreForce)"
+      HideWarningsAndErrors="$(HideWarningsAndErrors)"/>
+  </Target>
+
+
 
   <Target Name="_ExtrasFixRestoreFiles" 
           Condition="@(_RestoreGraphEntry->'%(OriginalTargetFrameworks)') != '' or @(_RestoreGraphEntry->'%(OriginalTargetFramework)') != ''"
-          AfterTargets="Restore">
+          Beforeargets="Restore">
 
     <ItemGroup>
       <_SdkTfmToOriginalMapTmp Include="@(_RestoreGraphEntry->'%(OriginalTargetFrameworks)')" TargetFramework="%(_RestoreGraphEntry.TargetFrameworks)" KeepMetadata="TargetFramework" />

--- a/Source/MSBuild.Sdk.Extras/Build/RIDs.targets
+++ b/Source/MSBuild.Sdk.Extras/Build/RIDs.targets
@@ -141,7 +141,7 @@
 
   <Target Name="_ExtrasFixRestoreFiles" 
           Condition="@(_RestoreGraphEntry->'%(OriginalTargetFrameworks)') != '' or @(_RestoreGraphEntry->'%(OriginalTargetFramework)') != ''"
-          Beforeargets="Restore">
+          BeforeTargets="Restore" DependsOnTargets="_SdkRestoreOriginal">
 
     <ItemGroup>
       <_SdkTfmToOriginalMapTmp Include="@(_RestoreGraphEntry->'%(OriginalTargetFrameworks)')" TargetFramework="%(_RestoreGraphEntry.TargetFrameworks)" KeepMetadata="TargetFramework" />

--- a/Source/MSBuild.Sdk.Extras/Build/RIDs.targets
+++ b/Source/MSBuild.Sdk.Extras/Build/RIDs.targets
@@ -141,7 +141,7 @@
 
   <Target Name="_ExtrasFixRestoreFiles" 
           Condition="@(_RestoreGraphEntry->'%(OriginalTargetFrameworks)') != '' or @(_RestoreGraphEntry->'%(OriginalTargetFramework)') != ''"
-          BeforeTargets="Restore" DependsOnTargets="_SdkRestoreOriginal">
+          BeforeTargets="Restore" AfterTargets="_GenerateProjectRestoreGraph" DependsOnTargets="_SdkRestoreOriginal">
 
     <ItemGroup>
       <_SdkTfmToOriginalMapTmp Include="@(_RestoreGraphEntry->'%(OriginalTargetFrameworks)')" TargetFramework="%(_RestoreGraphEntry.TargetFrameworks)" KeepMetadata="TargetFramework" />

--- a/Tests/Classlibrary/Classlibrary.csproj
+++ b/Tests/Classlibrary/Classlibrary.csproj
@@ -5,13 +5,14 @@
 	<PropertyGroup>
 		<!--<TargetFramework>uap10.0</TargetFramework>-->
 		<!--<TargetFrameworks>uap10.0;uap10.0.16299;monoandroid70;xamarin.ios10;xamarin.mac20</TargetFrameworks>-->
-    <TargetFrameworks>uap10.0;monoandroid70;xamarin.ios10;xamarin.mac20;net462</TargetFrameworks>
+    <!--<TargetFrameworks>uap10.0;monoandroid70;xamarin.ios10;xamarin.mac20;net462</TargetFrameworks>-->
+    <TargetFrameworks>netstandard2.0+unix;netstandard2.0+win;netstandard1.3</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>test.snk</AssemblyOriginatorKeyFile>
 	</PropertyGroup>
 
-  <ItemGroup>
+  <!--<ItemGroup>
     <ReferenceAssemblyProjectReference Include="..\Classlibrary.Ref\Classlibrary.Ref.csproj" />
   </ItemGroup>
 
@@ -29,7 +30,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'xamarin.mac20'">
     <Reference Include="System.Xml" />
-  </ItemGroup>
+  </ItemGroup>-->
 
 	<Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 	<Import Project="$(MSBuildThisFileDirectory)..\..\Source\MSBuild.Sdk.Extras\BuildMultiTargeting\MSBuild.Sdk.Extras.targets" />


### PR DESCRIPTION
Add support for RID's. 

What currently works: Adding a TFM with an RID like this `netstandard2.0+win` or a set like `netstandard2.0+unix;netstandard2.0+win`

It will set a define for both `NETSTANDARD2_0` and `NETSTANDARD2_0_UNIX`.

Currently requires `msbuild.exe` to build. Will require MSBuild 15.8 on .NET Core (2.1.4xx). You can build the csproj directly. Sln is a WIP.

/cc @Drawaes

To Do


- [ ] Pack correctly
- [ ] Restore from sln doesn't work
