### PR TITLE
Fixing wrong resource include rule for wpf

### DIFF
--- a/Source/MSBuild.Sdk.Extras/DefaultItems/Platforms/Xaml.targets
+++ b/Source/MSBuild.Sdk.Extras/DefaultItems/Platforms/Xaml.targets
@@ -17,7 +17,7 @@
     <ExtrasEnableDefaultPageItems Condition="'$(ExtrasEnableDefaultPageItems)' == ''">true</ExtrasEnableDefaultPageItems>
     <ExtrasEnableDefaultResourceItems Condition="'$(ExtrasEnableDefaultResourceItems)' == ''">true</ExtrasEnableDefaultResourceItems>
 
-    <ExtrasDefaultResourceIncludes Condition="'$(ExtrasDefaultResourceIncludes)' == ''">Themes\*.xaml;Resources\*.xaml</ExtrasDefaultResourceIncludes>
+    <ExtrasDefaultResourceIncludes Condition="'$(ExtrasDefaultResourceIncludes)' == ''">Resources\*.xaml</ExtrasDefaultResourceIncludes>
     <ExtrasDefaultPageExcludes Condition="'$(ExtrasDefaultPageExcludes)' != ''">$(ApplicationDefinitionFile);$(ExtrasDefaultResourceIncludes);$(ExtrasDefaultPageExcludes)</ExtrasDefaultPageExcludes>
     <ExtrasDefaultPageExcludes Condition="'$(ExtrasDefaultPageExcludes)' == ''">$(ApplicationDefinitionFile);$(ExtrasDefaultResourceIncludes)</ExtrasDefaultPageExcludes>
 


### PR DESCRIPTION
Files matching "Themes\*.xaml" must be added as pages and not as resources.
Otherwise it does not work with wpf applications having files like "Themes\generic.xaml" etc..
Having this not working out of the box would confuse every wpf developer i guess.