### PR TITLE
Find C#/VB targets using MSBuildToolsVersion

### DIFF
--- a/Source/MSBuild.Sdk.Extras/Build/Platforms/NETFramework.targets
+++ b/Source/MSBuild.Sdk.Extras/Build/Platforms/NETFramework.targets
@@ -10,7 +10,7 @@
   -->
   <PropertyGroup Condition="'$(LanguageTargets)' == '' and '$(OS)' == 'Windows_NT' and '$(MSBuildRuntimeType)' == 'Full'  ">
     <!-- Workaround for lack of XAML support in the new project system -->
-    <LanguageTargets Condition="'$(_SdkLanguageSourceName)' != 'FSharp'" >$(MSBuildExtensionsPath)\$(VisualStudioVersion)\Bin\Microsoft.$(_SdkLanguageSourceName).targets</LanguageTargets>
+    <LanguageTargets Condition="'$(_SdkLanguageSourceName)' != 'FSharp'" >$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Bin\Microsoft.$(_SdkLanguageSourceName).targets</LanguageTargets>
     <LanguageTargets Condition="'$(_SdkLanguageSourceName)' == 'FSharp'" >$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</LanguageTargets>
   </PropertyGroup>
 


### PR DESCRIPTION
Fixes #127 by using MSBuildToolsVersion instead of VisualStudioVersion,
since they will no longer match after Microsoft/msbuild#3778.

I grepped for other uses of `$(VisualStudioVersion)` and at a quick glance they all look fine.