### PR TITLE
Fixes to allow restore and build on macOS

### DIFF
--- a/Tools/MSBuild.DevLocal.targets
+++ b/Tools/MSBuild.DevLocal.targets
@@ -4,7 +4,7 @@
   <Target Name="_EnsureTempPackageSource" BeforeTargets="Restore;_LocalPublish">
     <PropertyGroup>
       <!-- TEMP is not defined by default on macOS. TMPDIR, however, is. -->
-      <TEMP Condition="'$(TEMP)' == ''">$(TMPDIR)</TEMP>
+      <TEMP Condition="'$(TEMP)' == '' and '$(TMPDIR)' != ''">$(TMPDIR)</TEMP>
       <TempPackagePath Condition="'$(TempPackagePath)' == ''">$(TEMP)\Packages</TempPackagePath>
     </PropertyGroup>
     <MakeDir Directories="$(TempPackagePath)" Condition="!Exists('$(TempPackagePath)')" />

--- a/Tools/MSBuild.DevLocal.targets
+++ b/Tools/MSBuild.DevLocal.targets
@@ -3,6 +3,8 @@
   <!-- Tools to make local dev easier -->
   <Target Name="_EnsureTempPackageSource" BeforeTargets="Restore;_LocalPublish">
     <PropertyGroup>
+      <!-- TEMP is not defined by default on macOS. TMPDIR, however, is. -->
+      <TEMP Condition="'$(TEMP)' == ''">$(TMPDIR)</TEMP>
       <TempPackagePath Condition="'$(TempPackagePath)' == ''">$(TEMP)\Packages</TempPackagePath>
     </PropertyGroup>
     <MakeDir Directories="$(TempPackagePath)" Condition="!Exists('$(TempPackagePath)')" />
@@ -14,7 +16,8 @@
     </ItemGroup>
 
     <Delete Files="@(ToDelete)"/>
-    <Exec Command='rd "$(NuGetPackageRoot)$(PackageId.ToLowerInvariant())" /q /s' Condition="Exists('$(NuGetPackageRoot)$(PackageId.ToLowerInvariant())')"/>
+    <Exec Command='rd "$(NuGetPackageRoot)$(PackageId.ToLowerInvariant())" /q /s' Condition="Exists('$(NuGetPackageRoot)$(PackageId.ToLowerInvariant())') and $([MSBuild]::IsOSPlatform(Windows))"/>
+    <Exec Command='rm -rf "$(NuGetPackageRoot)$(PackageId.ToLowerInvariant())"' Condition="Exists('$(NuGetPackageRoot)$(PackageId.ToLowerInvariant())') and !$([MSBuild]::IsOSPlatform(Windows))"/>
   </Target>
 
   <Target Name="_SetFixedVersion"


### PR DESCRIPTION
Does mostly what the title says. Necessary because I'm working on some Xamarin.Mac-specific fixes (for a later PR), and these need to be tested with VSMac, on macOS. Thanks!