### PR TITLE
Correctly select Windows.winmd on older SDKs

### DIFF
--- a/Source/MSBuild.Sdk.Extras/Build/Platforms/Windows.targets
+++ b/Source/MSBuild.Sdk.Extras/Build/Platforms/Windows.targets
@@ -62,7 +62,7 @@
     <TargetPlatformMinVersion Condition="'$(TargetPlatformMinVersion)' == ''">$([System.Version]::Parse('$(_SdkShortFrameworkVersion)')).0</TargetPlatformMinVersion>
 
     <!-- Decide whether to use the new version metadata, or the old one -->
-    <_UseVersionedWindowsWinmdFile Condition="$([System.Version]::Parse('$(TargetPlatformVersion)')) >= $([System.Version]::Parse('10.0.16299.0'))">true</_UseVersionedWindowsWinmdFile>
+    <_ExtrasUseVersionedWindowsWinmdFile Condition="$([System.Version]::Parse('$(TargetPlatformVersion)')) >= $([System.Version]::Parse('10.0.16299.0'))">true</_ExtrasUseVersionedWindowsWinmdFile>
 
     <!-- Need to override the built-in implicit defines for UAP (UAP10_0_10240) or it'll be NETCORE5_0 -->
     <ImplicitFrameworkDefine Condition="'$(DisableImplicitFrameworkDefines)' != 'true' AND '$(_SdkLanguageSourceName)' != 'VisualBasic'">UAP$(_SdkShortFrameworkVersion.Replace('.', '_'));UAP$(TargetPlatformMinVersion.Replace('.', '_'))</ImplicitFrameworkDefine>
@@ -70,8 +70,8 @@
 
     <CopyLocalLockFileAssemblies Condition="'$(CopyLocalLockFileAssemblies)' == ''">false</CopyLocalLockFileAssemblies>
 
-    <WindowsWinmdFile Condition="'$(_UseVersionedWindowsWinmdFile)' == 'true' AND Exists('$(MSBuildProgramFiles32)\Windows Kits\10\UnionMetadata\$(TargetPlatformVersion)\Windows.winmd')">$(MSBuildProgramFiles32)\Windows Kits\10\UnionMetadata\$(TargetPlatformVersion)\Windows.winmd</WindowsWinmdFile>
-    <WindowsWinmdFile Condition="'$(_UseVersionedWindowsWinmdFile)' != 'true' AND Exists('$(MSBuildProgramFiles32)\Windows Kits\10\UnionMetadata\Windows.winmd')">$(MSBuildProgramFiles32)\Windows Kits\10\UnionMetadata\Windows.winmd</WindowsWinmdFile>
+    <WindowsWinmdFile Condition="'$(_ExtrasUseVersionedWindowsWinmdFile)' == 'true' AND Exists('$(MSBuildProgramFiles32)\Windows Kits\10\UnionMetadata\$(TargetPlatformVersion)\Windows.winmd')">$(MSBuildProgramFiles32)\Windows Kits\10\UnionMetadata\$(TargetPlatformVersion)\Windows.winmd</WindowsWinmdFile>
+    <WindowsWinmdFile Condition="'$(_ExtrasUseVersionedWindowsWinmdFile)' != 'true' AND Exists('$(MSBuildProgramFiles32)\Windows Kits\10\UnionMetadata\Windows.winmd')">$(MSBuildProgramFiles32)\Windows Kits\10\UnionMetadata\Windows.winmd</WindowsWinmdFile>
     <ImplicitlyExpandTargetPlatform>false</ImplicitlyExpandTargetPlatform>
   </PropertyGroup>
 

--- a/Source/MSBuild.Sdk.Extras/Build/Platforms/Windows.targets
+++ b/Source/MSBuild.Sdk.Extras/Build/Platforms/Windows.targets
@@ -61,13 +61,17 @@
     <TargetPlatformMinVersion Condition="'$(TargetPlatformMinVersion)' == '' AND '$(_SdkShortFrameworkVersion)' == '10.0'">10.0.15063.0</TargetPlatformMinVersion>
     <TargetPlatformMinVersion Condition="'$(TargetPlatformMinVersion)' == ''">$([System.Version]::Parse('$(_SdkShortFrameworkVersion)')).0</TargetPlatformMinVersion>
 
+    <!-- Decide whether to use the new version metadata, or the old one -->
+    <_UseVersionedWindowsWinmdFile Condition="$([System.Version]::Parse('$(TargetPlatformVersion)')) >= $([System.Version]::Parse('10.0.16299.0'))">true</_UseVersionedWindowsWinmdFile>
+
     <!-- Need to override the built-in implicit defines for UAP (UAP10_0_10240) or it'll be NETCORE5_0 -->
     <ImplicitFrameworkDefine Condition="'$(DisableImplicitFrameworkDefines)' != 'true' AND '$(_SdkLanguageSourceName)' != 'VisualBasic'">UAP$(_SdkShortFrameworkVersion.Replace('.', '_'));UAP$(TargetPlatformMinVersion.Replace('.', '_'))</ImplicitFrameworkDefine>
     <ImplicitFrameworkDefine Condition="'$(DisableImplicitFrameworkDefines)' != 'true' AND '$(_SdkLanguageSourceName)' == 'VisualBasic'">UAP$(_SdkShortFrameworkVersion.Replace('.', '_'))=-1,UAP$(TargetPlatformMinVersion.Replace('.', '_'))</ImplicitFrameworkDefine>
 
     <CopyLocalLockFileAssemblies Condition="'$(CopyLocalLockFileAssemblies)' == ''">false</CopyLocalLockFileAssemblies>
 
-    <WindowsWinmdFile Condition="Exists('$(MSBuildProgramFiles32)\Windows Kits\10\UnionMetadata\$(TargetPlatformVersion)\Windows.winmd')">$(MSBuildProgramFiles32)\Windows Kits\10\UnionMetadata\$(TargetPlatformVersion)\Windows.winmd</WindowsWinmdFile>
+    <WindowsWinmdFile Condition="'$(_UseVersionedWindowsWinmdFile)' == 'true' AND Exists('$(MSBuildProgramFiles32)\Windows Kits\10\UnionMetadata\$(TargetPlatformVersion)\Windows.winmd')">$(MSBuildProgramFiles32)\Windows Kits\10\UnionMetadata\$(TargetPlatformVersion)\Windows.winmd</WindowsWinmdFile>
+    <WindowsWinmdFile Condition="'$(_UseVersionedWindowsWinmdFile)' != 'true' AND Exists('$(MSBuildProgramFiles32)\Windows Kits\10\UnionMetadata\Windows.winmd')">$(MSBuildProgramFiles32)\Windows Kits\10\UnionMetadata\Windows.winmd</WindowsWinmdFile>
     <ImplicitlyExpandTargetPlatform>false</ImplicitlyExpandTargetPlatform>
   </PropertyGroup>
 


### PR DESCRIPTION
Prior to v10.0.16299.0, the .winmd files were not placed in a versioned sub-directory.

Not only for the `UnionMetadata` but for all the other references in the `$(MSBuildProgramFiles32)\Windows Kits\10\References` folder. They were originally placed in a `Assembly.Name/Version/Assembly.Name.winmd` location.