### PR TITLE
Rolling back UWP to 6.1.9

### DIFF
--- a/Source/MSBuild.Sdk.Extras/DefaultItems/ImplicitPackages.targets
+++ b/Source/MSBuild.Sdk.Extras/DefaultItems/ImplicitPackages.targets
@@ -8,7 +8,7 @@
     Package Version property for Implicit Packages included in the props file
   -->
   <PropertyGroup Condition="'$(ExtrasUwpMetaPackageVersion)' == ''">
-    <ExtrasUwpMetaPackageVersion>6.2.2</ExtrasUwpMetaPackageVersion>
+    <ExtrasUwpMetaPackageVersion>6.1.9</ExtrasUwpMetaPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(ExtrasTizenMetaPackageVersion)' == ''">


### PR DESCRIPTION
Rolling back UWP to the latest stable version on NuGet as 6.2.x packages are unpublished and have issues. As we're trying to support .netcore3 in Prism as well, we're using the latest MSBuild.Sdk.Extras, which forces us to 6.2.2 for UWP which in turn results in following error:

> Could not load type 'System.Runtime.CompilerServices.IAsyncStateMachine' from assembly 'System.Runtime, Version=4.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'.