### PR TITLE
Fix rid-tfm PDB placement issue.

### DIFF
--- a/Source/MSBuild.Sdk.Extras/Build/RIDs.targets
+++ b/Source/MSBuild.Sdk.Extras/Build/RIDs.targets
@@ -164,7 +164,7 @@
 
        <!-- Include the runtimes files -->
       <None Include="@(_BuildOutputInPackageWithRid)" PackagePath="runtimes/%(_BuildOutputInPackageWithRid.Rid)/lib/%(_BuildOutputInPackageWithRid.TargetFramework)" Pack="true" />
-      <None Include="@(_TargetPathsToSymbolsWithRid)" PackagePath="runtimes/%(_BuildOutputInPackageWithRid.Rid)/lib/%(_BuildOutputInPackageWithRid.TargetFramework)" Pack="true" />
+      <None Include="@(_TargetPathsToSymbolsWithRid)" PackagePath="runtimes/%(_TargetPathsToSymbolsWithRid.Rid)/lib/%(_TargetPathsToSymbolsWithRid.TargetFramework)" Pack="true" />
     </ItemGroup>  
     
   </Target>


### PR DESCRIPTION
Looks like the underlying issue was a typo with the MSBuild item metadata selector causing a combinatorial explosion in the msbuild items.

Fixes #171 
