### PR TITLE
Fix WPF Regression #158 when .net-core 3.0 preview is not installed

### DIFF
--- a/Source/MSBuild.Sdk.Extras/Build/ExtrasShim.targets
+++ b/Source/MSBuild.Sdk.Extras/Build/ExtrasShim.targets
@@ -26,7 +26,7 @@
     <UseWindowsForms Condition="'$(UseWindowsForms)' == '' and '$(ExtrasEnableWinFormsProjectSetup)' == 'true' ">true</UseWindowsForms>
 
     <!-- Until there's a discreet property for this, default based on Wpf/WinForms -->
-    <ExtrasUseWindowsDesktopApp Condition="'$(UseWpf)' == 'true' or '$(UseWindowsForms)' == 'true'">true</ExtrasUseWindowsDesktopApp>
+    <ExtrasUseWindowsDesktopApp Condition="'$(_ExtrasHasDesktopSdk)' == 'true' and ('$(UseWpf)' == 'true' or '$(UseWindowsForms)' == 'true')">true</ExtrasUseWindowsDesktopApp>
     <ExtrasUseWindowsDesktopApp Condition="'$(ExtrasUseWindowsDesktopApp)' == '' ">false</ExtrasUseWindowsDesktopApp>
   </PropertyGroup>
 


### PR DESCRIPTION
Previously the changed line caused `$(ExtrasUseWindowsDesktopApp)` to be true even when the desktop Sdk is not available. `$(ExtrasUseWindowsDesktopApp)` is used to turn off Wpf and WinForms tooling provided by MSBuildSdkExtras which prevents collisions with the tooling provided by Microsoft.NET.Sdk.WindowsDesktop. That means it shouldn't be true when the sdk isn't available.