### PR TITLE
Fix non-existing language targets restore

### DIFF
--- a/Source/Directory.Build.targets
+++ b/Source/Directory.Build.targets
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19367-01" PrivateAssets="All"/>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(IsCloudBuild)' == 'true'">    
+  <ItemGroup Condition="'$(IsCloudBuild)' == 'true' and '$(DisableNerdBank)'!='true'">    
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.0.26" PrivateAssets="All"/>
   </ItemGroup>
 

--- a/Source/MSBuild.Sdk.Extras/Build/LanguageTargets/CheckMissing.targets
+++ b/Source/MSBuild.Sdk.Extras/Build/LanguageTargets/CheckMissing.targets
@@ -13,7 +13,7 @@
 
   <!-- Check to see if the Lang targets exist and if not, trigger an error on Compile -->
   <!-- We clear out the lang targets so the defaults are used for the error to show -->
-  <PropertyGroup Condition="'$(_ExtrasSkipTargetsCheck)' != 'true' and '$(_SdkLanguageTargetsMissing)' == 'true' ">
+  <PropertyGroup Condition="'$(_ExtrasSkipTargetsCheck)' != 'true' ">
 
     <!-- Reset LanguageTargets Eval-->
     <!-- https://github.com/dotnet/sdk/blob/581f5371dac022ad2b3e5bcdbb2e576bd73b5c4a/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.targets#L28-L37 -->
@@ -30,7 +30,7 @@
 
   <!-- Import common targets so NuGet restore succeeds -->
   <!-- https://github.com/dotnet/sdk/blob/979eed136b786b6e2d77f567eb5a368952982740/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.targets#L33 -->
-  <Import Condition="'$(_SdkLanguageTargetsMissing)' == 'true' " Project="$(LanguageTargets)" />
+  <Import Project="$(LanguageTargets)" />
 
 
   <Target Name="_ShowMissingLanguageTargetsError" BeforeTargets="_CheckForUnsupportedTargetFramework" Condition="'$(_SdkLanguageTargetsMissing)' == 'true' and '$(_SdkIgnoreMissingLanguageTargetsError)' != 'true' ">

--- a/Source/MSBuild.Sdk.Extras/Build/LanguageTargets/CheckMissing.targets
+++ b/Source/MSBuild.Sdk.Extras/Build/LanguageTargets/CheckMissing.targets
@@ -11,9 +11,16 @@
     <_SdkLanguageTargetsMissing Condition="'$(_SdkLanguageTargetsMissing)' == ''">true</_SdkLanguageTargetsMissing>
   </PropertyGroup>
 
+  <!-- Check if the Common targets have been loaded, see https://github.com/onovotny/MSBuildSdkExtras/pull/186 -->
+  <!-- https://github.com/microsoft/msbuild/blob/d42d3504057ef2b88dd4f68c4bfc5591371bd6fe/src/Tasks/Microsoft.Common.targets#L32-L43 -->
+  <PropertyGroup Condition=" '$(CommonTargetsPath)' == '' Or '$(MSBuildVersion)' &gt;= '16.0' ">
+    <_SdkLanguageTargetsMissing Condition="'$(CommonTargetsPath)'!=''">false</_SdkLanguageTargetsMissing>
+    <_SdkLanguageTargetsMissing Condition="'$(_SdkLanguageTargetsMissing)' == ''">true</_SdkLanguageTargetsMissing>
+  </PropertyGroup>
+
   <!-- Check to see if the Lang targets exist and if not, trigger an error on Compile -->
   <!-- We clear out the lang targets so the defaults are used for the error to show -->
-  <PropertyGroup Condition="'$(_ExtrasSkipTargetsCheck)' != 'true' ">
+  <PropertyGroup Condition="'$(_ExtrasSkipTargetsCheck)' != 'true' and '$(_SdkLanguageTargetsMissing)' == 'true' ">
 
     <!-- Reset LanguageTargets Eval-->
     <!-- https://github.com/dotnet/sdk/blob/581f5371dac022ad2b3e5bcdbb2e576bd73b5c4a/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.targets#L28-L37 -->
@@ -30,7 +37,7 @@
 
   <!-- Import common targets so NuGet restore succeeds -->
   <!-- https://github.com/dotnet/sdk/blob/979eed136b786b6e2d77f567eb5a368952982740/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.targets#L33 -->
-  <Import Project="$(LanguageTargets)" />
+  <Import Condition=" '$(_SdkLanguageTargetsMissing)' == 'true' " Project="$(LanguageTargets)" />
 
 
   <Target Name="_ShowMissingLanguageTargetsError" BeforeTargets="_CheckForUnsupportedTargetFramework" Condition="'$(_SdkLanguageTargetsMissing)' == 'true' and '$(_SdkIgnoreMissingLanguageTargetsError)' != 'true' ">

--- a/TestProjects/Linux-C#/Directory.Build.props
+++ b/TestProjects/Linux-C#/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <SolutionDir Condition="'$(SolutionDir)' == ''">$(MSBuildThisFileDirectory)</SolutionDir>
+  </PropertyGroup>
+
+  <Import Project="$(MSBuildThisFileDirectory)..\$(MSBuildThisFile)"/>
+
+</Project>

--- a/TestProjects/Linux-C#/Linux-CS.sln
+++ b/TestProjects/Linux-C#/Linux-CS.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29230.61
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "netstd2Library", "netstd2Library\netstd2Library.csproj", "{ED027E36-643F-44C0-A297-34D565859D16}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "cross-ios-netstd2", "cross-ios-netstd2\cross-ios-netstd2.csproj", "{C87855F6-314C-4BA6-AFA9-F979D8850050}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{ED027E36-643F-44C0-A297-34D565859D16}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ED027E36-643F-44C0-A297-34D565859D16}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ED027E36-643F-44C0-A297-34D565859D16}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ED027E36-643F-44C0-A297-34D565859D16}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C87855F6-314C-4BA6-AFA9-F979D8850050}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C87855F6-314C-4BA6-AFA9-F979D8850050}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C87855F6-314C-4BA6-AFA9-F979D8850050}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C87855F6-314C-4BA6-AFA9-F979D8850050}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {59FA0C61-E338-40D3-BBB4-966BC1CDB464}
+	EndGlobalSection
+EndGlobal

--- a/TestProjects/Linux-C#/Linux-CS/Linux-CS.sln
+++ b/TestProjects/Linux-C#/Linux-CS/Linux-CS.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29230.61
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "netstd2Library", "netstd2Library\netstd2Library.csproj", "{ED027E36-643F-44C0-A297-34D565859D16}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "cross-ios-netstd2", "cross-ios-netstd2\cross-ios-netstd2.csproj", "{C87855F6-314C-4BA6-AFA9-F979D8850050}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{ED027E36-643F-44C0-A297-34D565859D16}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ED027E36-643F-44C0-A297-34D565859D16}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ED027E36-643F-44C0-A297-34D565859D16}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ED027E36-643F-44C0-A297-34D565859D16}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C87855F6-314C-4BA6-AFA9-F979D8850050}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C87855F6-314C-4BA6-AFA9-F979D8850050}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C87855F6-314C-4BA6-AFA9-F979D8850050}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C87855F6-314C-4BA6-AFA9-F979D8850050}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {59FA0C61-E338-40D3-BBB4-966BC1CDB464}
+	EndGlobalSection
+EndGlobal

--- a/TestProjects/Linux-C#/Linux-CS/cross-ios-netstd2/Class1.cs
+++ b/TestProjects/Linux-C#/Linux-CS/cross-ios-netstd2/Class1.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace cross_ios_netstd2
+{
+    public class Class1
+    {
+    }
+}

--- a/TestProjects/Linux-C#/Linux-CS/cross-ios-netstd2/cross-ios-netstd2.csproj
+++ b/TestProjects/Linux-C#/Linux-CS/cross-ios-netstd2/cross-ios-netstd2.csproj
@@ -1,0 +1,8 @@
+﻿<Project Sdk="MSBuild.Sdk.Extras">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;xamarinios10</TargetFrameworks>
+    <RootNamespace>cross_ios_netstd2</RootNamespace>
+  </PropertyGroup>
+
+</Project>

--- a/TestProjects/Linux-C#/Linux-CS/netstd2Library/Class1.cs
+++ b/TestProjects/Linux-C#/Linux-CS/netstd2Library/Class1.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace netstd2Library
+{
+    public class Class1
+    {
+    }
+}

--- a/TestProjects/Linux-C#/Linux-CS/netstd2Library/netstd2Library.csproj
+++ b/TestProjects/Linux-C#/Linux-CS/netstd2Library/netstd2Library.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/TestProjects/Linux-C#/cross-ios-netstd2/Class1.cs
+++ b/TestProjects/Linux-C#/cross-ios-netstd2/Class1.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace cross_ios_netstd2
+{
+    public class Class1
+    {
+    }
+}

--- a/TestProjects/Linux-C#/cross-ios-netstd2/cross-ios-netstd2.csproj
+++ b/TestProjects/Linux-C#/cross-ios-netstd2/cross-ios-netstd2.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="MSBuild.Sdk.Extras">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;xamarinios10;uap10.0.16299</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;xamarinios10</TargetFrameworks>
+    <RootNamespace>cross_ios_netstd2</RootNamespace>
+  </PropertyGroup>
+
+</Project>

--- a/TestProjects/Linux-C#/cross-ios-netstd2/cross-ios-netstd2.csproj
+++ b/TestProjects/Linux-C#/cross-ios-netstd2/cross-ios-netstd2.csproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;xamarinios10;uap10.0.16299</TargetFrameworks>
-    <TargetFrameworks>netstandard2.0;xamarinios10</TargetFrameworks>
-    <RootNamespace>cross_ios_netstd2</RootNamespace>
   </PropertyGroup>
 
 </Project>

--- a/TestProjects/Linux-C#/netstd2Library/Class1.cs
+++ b/TestProjects/Linux-C#/netstd2Library/Class1.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace netstd2Library
+{
+    public class Class1
+    {
+    }
+}

--- a/TestProjects/Linux-C#/netstd2Library/netstd2Library.csproj
+++ b/TestProjects/Linux-C#/netstd2Library/netstd2Library.csproj
@@ -1,0 +1,11 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\cross-ios-netstd2\cross-ios-netstd2.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/TestProjects/NuGet.config
+++ b/TestProjects/NuGet.config
@@ -1,6 +1,6 @@
-<configuration>
+﻿<configuration>
   <packageSources>
-    <add key="Local" value="%temp%\Packages"/>
-    <add key="CI Builds" value="https://myget.org/F/msbuildsdkextras/api/v3/index.json"/>
+    <add key="Local" value="%TMPDIR%/Packages"/>
+    <!--<add key="CI Builds" value="https://myget.org/F/msbuildsdkextras/api/v3/index.json"/>-->
   </packageSources>
 </configuration>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,54 +1,131 @@
 trigger:
-  - master
-  - rel/*
+- master
+- rel/*
 
 pr:
-  - master
-  - rel/*
+- master
+- rel/*
 
-pool:
-  vmImage: windows-2019
+jobs:
+- job: Windows
+  pool:
+    vmImage: windows-2019
 
-variables:
-  BuildConfiguration: Release
+  variables:
+    BuildConfiguration: Release
 
-steps:
-- task: DotNetCoreCLI@2  
-  inputs:
-    command: custom
-    custom: tool
-    arguments: install --tool-path . nbgv
-  displayName: Install NBGV tool
+  steps:
+  - task: DotNetCoreCLI@2  
+    inputs:
+      command: custom
+      custom: tool
+      arguments: install --tool-path . nbgv
+    displayName: Install NBGV tool
 
-- script: nbgv cloud
-  displayName: Set Version
+  - script: nbgv cloud
+    displayName: Set Version
 
-- powershell: |
-    mkdir $Env:Temp\Packages -Force
-  displayName: Build
+  - powershell: |
+      mkdir $Env:Temp\Packages -Force
+    displayName: Create packages temp folder
 
-- task: DotNetCoreCLI@2
-  inputs:
-    command: pack
-    packagesToPack: Source/MSBuild.Sdk.Extras/MSBuild.Sdk.Extras.csproj
-    configuration: $(BuildConfiguration)
-    packDirectory: $(Build.ArtifactStagingDirectory)\Packages    
-    verbosityPack: Minimal
-  displayName: Build Package
+  - task: DotNetCoreCLI@2
+    inputs:
+      command: pack
+      packagesToPack: Source/MSBuild.Sdk.Extras/MSBuild.Sdk.Extras.csproj
+      configuration: $(BuildConfiguration)
+      packDirectory: $(Build.ArtifactStagingDirectory)\Packages    
+      verbosityPack: Minimal
+    displayName: Build Package
 
-- task: PowerShell@2
-  displayName: Authenticode Sign artifacts
-  inputs:
-    filePath: Tools\Sign-Package.ps1
-  env:
-    SignClientUser: $(SignClientUser)
-    SignClientSecret: $(SignClientSecret)
-    ArtifactDirectory: $(Build.ArtifactStagingDirectory)\Packages
-  condition: and(succeeded(), not(eq(variables['build.reason'], 'PullRequest')), not(eq(variables['SignClientSecret'], '')), not(eq(variables['SignClientUser'], '')))
+  - task: PowerShell@2
+    displayName: Authenticode Sign artifacts
+    inputs:
+      filePath: Tools\Sign-Package.ps1
+    env:
+      SignClientUser: $(SignClientUser)
+      SignClientSecret: $(SignClientSecret)
+      ArtifactDirectory: $(Build.ArtifactStagingDirectory)\Packages
+    condition: and(succeeded(), not(eq(variables['build.reason'], 'PullRequest')), not(eq(variables['SignClientSecret'], '')), not(eq(variables['SignClientUser'], '')))
 
-- task: PublishBuildArtifacts@1
-  displayName: Publish Artifacts  
-  inputs:
-    pathToPublish: $(Build.ArtifactStagingDirectory)\Packages
-    artifactType: container
-    artifactName: Package
+  - task: PublishBuildArtifacts@1
+    displayName: Publish Artifacts  
+    inputs:
+      pathToPublish: $(Build.ArtifactStagingDirectory)\Packages
+      artifactType: container
+      artifactName: Package
+
+
+- job: Linux
+  container: nventive/wasm-build:1.4.1
+  pool:
+    vmImage: 'ubuntu-16.04'
+
+  variables:
+    BuildConfiguration: Release
+    TMPDIR: /tmp
+    DisableNerdBank: true
+    PackageVersion: 42.42.42
+
+  steps:
+  - script: |
+      mkdir $TMPDIR/Packages
+    displayName: Create packages temp folder
+
+  - task: DotNetCoreCLI@2
+    inputs:
+      command: pack
+      packagesToPack: Source/MSBuild.Sdk.Extras/MSBuild.Sdk.Extras.csproj
+      configuration: $(BuildConfiguration)
+      packDirectory: $(TMPDIR)/Packages    
+      verbosityPack: Minimal
+    displayName: Build Package
+    
+  - bash: |
+      dotnet build --configuration Release $(build.sourcesdirectory)/TestProjects/Linux-C#/netstd2Library/netstd2Library.csproj
+      msbuild /r /p:Configuration=Release $(build.sourcesdirectory)/TestProjects/Linux-C#/netstd2Library/netstd2Library.csproj
+
+    displayName: '.NET Std Library with unavailable platform test'
+
+
+- job: macOS
+
+  strategy:
+    matrix:
+      Xamarin_5_16_0:
+        XamarinVersion: 5_16_0
+      Xamarin_5_12_0:
+        XamarinVersion: 5_12_0
+
+  pool:
+    vmImage: 'macOS-10.13'
+
+  variables:
+    BuildConfiguration: Release
+    TMPDIR: /tmp
+    DisableNerdBank: true
+    PackageVersion: 42.42.42
+
+  steps:
+
+  - bash: /bin/bash -c "sudo $AGENT_HOMEDIRECTORY/scripts/select-xamarin-sdk.sh $(XamarinVersion)"
+    displayName: Select Xamarin Version
+
+  - script: |
+      mkdir $TMPDIR/Packages
+    displayName: Create packages temp folder
+
+  - task: DotNetCoreCLI@2
+    inputs:
+      command: pack
+      packagesToPack: Source/MSBuild.Sdk.Extras/MSBuild.Sdk.Extras.csproj
+      configuration: $(BuildConfiguration)
+      packDirectory: $(TMPDIR)/Packages    
+      verbosityPack: Minimal
+    displayName: Build Package
+
+  - bash: |
+      dotnet build --configuration Release $(build.sourcesdirectory)/TestProjects/Linux-C#/netstd2Library/netstd2Library.csproj
+      msbuild /r /p:Configuration=Release $(build.sourcesdirectory)/TestProjects/Linux-C#/netstd2Library/netstd2Library.csproj
+
+    displayName: '.NET Std Library with unavailable platform test'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -120,9 +120,13 @@ jobs:
     
   - bash: |
       dotnet build --configuration Release $(build.sourcesdirectory)/TestProjects/Linux-C#/netstd2Library/netstd2Library.csproj
+
+    displayName: '.NET Core: .NET Std Library with unavailable platform test'
+    
+  - bash: |
       msbuild /r /p:Configuration=Release $(build.sourcesdirectory)/TestProjects/Linux-C#/netstd2Library/netstd2Library.csproj
 
-    displayName: '.NET Std Library with unavailable platform test'
+    displayName: 'MSBuild: .NET Std Library with unavailable platform test'
 
 
 - job: macOS
@@ -163,6 +167,10 @@ jobs:
 
   - bash: |
       dotnet build --configuration Release $(build.sourcesdirectory)/TestProjects/Linux-C#/netstd2Library/netstd2Library.csproj
+
+    displayName: '.NET Core: .NET Std Library with unavailable platform test'
+    
+  - bash: |
       msbuild /r /p:Configuration=Release $(build.sourcesdirectory)/TestProjects/Linux-C#/netstd2Library/netstd2Library.csproj
 
-    displayName: '.NET Std Library with unavailable platform test'
+    displayName: 'MSBuild: .NET Std Library with unavailable platform test'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,6 +55,43 @@ jobs:
       artifactType: container
       artifactName: Package
 
+- job: Windows_Tests
+  pool:
+    vmImage: windows-2019
+
+  variables:
+    BuildConfiguration: Release
+    TMPDIR: $(Build.ArtifactStagingDirectory)
+    DisableNerdBank: true
+    PackageVersion: 42.42.42
+
+  steps:
+  - powershell: |
+      mkdir $(Build.ArtifactStagingDirectory)\Packages -Force
+    displayName: Create packages temp folder
+
+  - task: DotNetCoreCLI@2
+    inputs:
+      command: pack
+      packagesToPack: Source/MSBuild.Sdk.Extras/MSBuild.Sdk.Extras.csproj
+      configuration: $(BuildConfiguration)
+      packDirectory: $(Build.ArtifactStagingDirectory)\Packages    
+      verbosityPack: Minimal
+    displayName: Build Package
+
+  - task: MSBuild@1
+    inputs:
+      solution: '$(build.sourcesdirectory)\TestProjects\Windows-Desktop-C#\Windows-Desktop.sln'
+      msbuildArguments: /r /p:SignManifests=false
+      configution: $(BuildConfiguration)
+    displayName: MSBuild Test Projects 1
+
+  - task: MSBuild@1
+    inputs:
+      solution: '$(build.sourcesdirectory)\TestProjects\Linux-C#\netstd2Library\netstd2Library.csproj'
+      msbuildArguments: /r
+      configution: $(BuildConfiguration)
+    displayName: MSBuild Test Projects 2
 
 - job: Linux
   container: nventive/wasm-build:1.4.1


### PR DESCRIPTION
This PR fixes the scenario where building a head project should only build the proper dependency chain and ignore unknown targets (e.g. `xamarinios10` on linux).

The current behavior is the following:
```
/mnt/c/temp/msbe-linux/ClassLibrary1/ClassLibrary1.csproj error MSB4057: The target "_GetRestoreSettingsPerFramework" does not exist in the project. [/mnt/c/temp/msbe-linux/ClassLibrary1/ClassLibrary1.csproj]
```

This PR also adds validations on Linux and macOS.

For the Linux tests, the MSBuild version installed version in the azure devops hosted agents is not working properly (some missing methods in nuget), so the build needs to rely on a container that has the proper setup applied. 

See https://github.com/nventive/docker/blob/master/wasm-build/Dockerfile