### PR TITLE
Use the `XAJavaInterop1` codegen by default

### DIFF
--- a/Source/MSBuild.Sdk.Extras/Build/Platforms/Xamarin/Xamarin.Android.targets
+++ b/Source/MSBuild.Sdk.Extras/Build/Platforms/Xamarin/Xamarin.Android.targets
@@ -5,11 +5,12 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v5.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v6.1</TargetFrameworkVersion>
     <AndroidUseLatestPlatformSdk Condition="'$(AndroidUseLatestPlatformSdk)' == ''">false</AndroidUseLatestPlatformSdk>
     <!-- This is here to prevent a warning in the Xamarin.Android.Common.Debugging.targets when a blank is passed into _GetPrimaryCpuAbi -->
     <AdbTarget Condition="'$(AdbTarget)' == ''">none</AdbTarget>
     <AndroidClassParser Condition="'$(AndroidClassParser)' == ''">class-parse</AndroidClassParser>
+    <AndroidCodegenTarget Condition="'$(AndroidCodegenTarget)' == '' And $(TargetFrameworkVersion.TrimStart('vV')) &gt; 6.0">XAJavaInterop1</AndroidCodegenTarget>
     <AndroidUseIntermediateDesignerFile Condition=" '$(AndroidUseIntermediateDesignerFile)' == '' ">True</AndroidUseIntermediateDesignerFile>
     <DesignTimeBuild Condition=" '$(DesignTimeBuild)' == '' ">false</DesignTimeBuild>
   </PropertyGroup>


### PR DESCRIPTION
See: https://docs.microsoft.com/en-us/xamarin/android/deploy-test/building-apps/build-process#binding-project-build-properties

Basically, smaller, faster bindings - this does require 6.1 or later, so there's a condition for that.

This also bumps TargetFrameworkVersion to something a bit more sane (really I'd like to see this go to 9.0)